### PR TITLE
v1.0.1: fix sqlite ResourceWarning in test suite

### DIFF
--- a/tests/test_cards_asset.py
+++ b/tests/test_cards_asset.py
@@ -10,11 +10,14 @@ class CardsAssetTests(unittest.TestCase):
         db_path = Path("src/arena_companion/assets/cards.sqlite")
         self.assertTrue(db_path.exists())
 
-        with sqlite3.connect(db_path) as conn:
+        conn = sqlite3.connect(db_path)
+        try:
             tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
             self.assertIn("cards", tables)
             count = conn.execute("SELECT COUNT(*) FROM cards").fetchone()[0]
             self.assertGreaterEqual(count, 1)
+        finally:
+            conn.close()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
﻿## Summary
- close sqlite connection explicitly in cards asset test
- removes intermittent `ResourceWarning: unclosed database` during suite runs

## Validation
- `python -W error::ResourceWarning -m unittest discover -s tests -p "test_*.py" -v`
- Result: 38 passed, 0 failed
