### PR TITLE
feat: implement incremental ingest checkpoint/resume

### DIFF
--- a/docs/benchmark_replay_checkpoint.json
+++ b/docs/benchmark_replay_checkpoint.json
@@ -1,0 +1,13 @@
+{
+  "initial_replay_lines": 50000,
+  "appended_lines": 100,
+  "first_replay_inserted": 50000,
+  "second_replay_inserted": 0,
+  "third_replay_inserted": 100,
+  "forced_replay_inserted": 0,
+  "first_replay_ms": 234.61,
+  "second_replay_ms": 1.34,
+  "third_replay_ms": 10.73,
+  "forced_full_replay_ms": 200.27,
+  "startup_speedup_factor": 174.99
+}

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -28,3 +28,18 @@ Report artifact: `docs/benchmark_report.json`
 - Baseline index coverage is active for key lookup/order paths.
 - Query latency is well below a 50 ms interactive target for benchmarked reads.
 - Ingest-like insert throughput is sufficient for local log replay/tail workloads at 1.0.0 scope.
+
+## Replay Checkpoint Benchmark (Issue #71)
+Benchmark script: `scripts/benchmark_replay_checkpoint.py`  
+Report artifact: `docs/benchmark_replay_checkpoint.json`
+
+### Results (2026-03-30 run)
+- first startup replay (`50,000` lines): `234.61 ms`
+- checkpointed startup replay (no new lines): `1.34 ms`
+- replay after appending `100` lines: `10.73 ms`
+- forced full replay (`50,100` lines): `200.27 ms`
+- startup speedup factor (first vs checkpointed): `174.99x`
+
+### Conclusion
+- Checkpoint resume avoids full-file replay when no new bytes are present.
+- Forced full replay remains available for reset/reprocess workflows.

--- a/scripts/benchmark_replay_checkpoint.py
+++ b/scripts/benchmark_replay_checkpoint.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from arena_companion.db.connection import apply_migrations
+from arena_companion.ingest.log_discovery import resolve_log_paths
+from arena_companion.services.ingest_service import IngestService
+
+
+def _write_lines(path: Path, count: int, start: int = 0) -> None:
+    path.write_text("".join(f"benchmark-line-{idx}\n" for idx in range(start, start + count)), encoding="utf-8")
+
+
+def benchmark() -> dict[str, float | int]:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        current = root / "Player.log"
+        previous = root / "Player-prev.log"
+        db_path = root / "arena_companion.db"
+
+        _write_lines(previous, count=50000)
+        current.write_text("", encoding="utf-8")
+
+        apply_migrations(db_path)
+        service = IngestService(db_path, resolve_log_paths(str(root)))
+
+        t0 = time.perf_counter()
+        inserted_first = service.replay_previous_session()
+        first_ms = (time.perf_counter() - t0) * 1000
+
+        t1 = time.perf_counter()
+        inserted_second = service.replay_previous_session()
+        second_ms = (time.perf_counter() - t1) * 1000
+
+        with previous.open("a", encoding="utf-8") as handle:
+            for idx in range(50000, 50100):
+                handle.write(f"benchmark-line-{idx}\n")
+
+        t2 = time.perf_counter()
+        inserted_third = service.replay_previous_session()
+        third_ms = (time.perf_counter() - t2) * 1000
+
+        t3 = time.perf_counter()
+        inserted_forced = service.replay_previous_session(force_full_replay=True)
+        forced_ms = (time.perf_counter() - t3) * 1000
+
+        speedup = (first_ms / second_ms) if second_ms > 0 else 0.0
+        return {
+            "initial_replay_lines": 50000,
+            "appended_lines": 100,
+            "first_replay_inserted": inserted_first,
+            "second_replay_inserted": inserted_second,
+            "third_replay_inserted": inserted_third,
+            "forced_replay_inserted": inserted_forced,
+            "first_replay_ms": round(first_ms, 2),
+            "second_replay_ms": round(second_ms, 2),
+            "third_replay_ms": round(third_ms, 2),
+            "forced_full_replay_ms": round(forced_ms, 2),
+            "startup_speedup_factor": round(speedup, 2),
+        }
+
+
+def main() -> int:
+    report = benchmark()
+    report_path = Path("docs") / "benchmark_replay_checkpoint.json"
+    report_path.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/arena_companion/db/migrations/0003_ingest_checkpoints.sql
+++ b/src/arena_companion/db/migrations/0003_ingest_checkpoints.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS ingest_checkpoints (
+    source_file TEXT PRIMARY KEY,
+    last_offset INTEGER NOT NULL,
+    last_segment_id INTEGER,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(last_segment_id) REFERENCES raw_segments(id)
+);
+
+COMMIT;

--- a/src/arena_companion/db/repositories/ingest_checkpoints.py
+++ b/src/arena_companion/db/repositories/ingest_checkpoints.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class IngestCheckpoint:
+    source_file: str
+    last_offset: int
+    last_segment_id: int | None
+
+
+def _connect(db_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.execute("PRAGMA foreign_keys=ON;")
+    return conn
+
+
+def load_checkpoint(db_path: Path, source_file: Path) -> IngestCheckpoint | None:
+    conn = _connect(db_path)
+    try:
+        row = conn.execute(
+            """
+            SELECT source_file, last_offset, last_segment_id
+            FROM ingest_checkpoints
+            WHERE source_file=?
+            """,
+            (str(source_file),),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    if row is None:
+        return None
+    return IngestCheckpoint(source_file=row[0], last_offset=int(row[1]), last_segment_id=row[2])
+
+
+def upsert_checkpoint(
+    db_path: Path,
+    source_file: Path,
+    last_offset: int,
+    last_segment_id: int | None,
+) -> None:
+    conn = _connect(db_path)
+    try:
+        conn.execute(
+            """
+            INSERT INTO ingest_checkpoints(source_file, last_offset, last_segment_id, updated_at)
+            VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(source_file) DO UPDATE SET
+                last_offset=excluded.last_offset,
+                last_segment_id=excluded.last_segment_id,
+                updated_at=CURRENT_TIMESTAMP
+            """,
+            (str(source_file), int(last_offset), last_segment_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def delete_checkpoint(db_path: Path, source_file: Path) -> None:
+    conn = _connect(db_path)
+    try:
+        conn.execute("DELETE FROM ingest_checkpoints WHERE source_file=?", (str(source_file),))
+        conn.commit()
+    finally:
+        conn.close()

--- a/src/arena_companion/db/schema.sql
+++ b/src/arena_companion/db/schema.sql
@@ -153,6 +153,14 @@ CREATE TABLE IF NOT EXISTS app_settings (
     value_json TEXT NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS ingest_checkpoints (
+    source_file TEXT PRIMARY KEY,
+    last_offset INTEGER NOT NULL,
+    last_segment_id INTEGER,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(last_segment_id) REFERENCES raw_segments(id)
+);
+
 CREATE TABLE IF NOT EXISTS collection_snapshots (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     captured_at TEXT NOT NULL,

--- a/src/arena_companion/ingest/log_follower.py
+++ b/src/arena_companion/ingest/log_follower.py
@@ -13,13 +13,18 @@ class FollowState:
     last_size: int = 0
 
 
-def replay_file(source_file: Path) -> list[RawSegment]:
+def replay_file(source_file: Path, start_offset: int = 0) -> list[RawSegment]:
     if not source_file.exists():
         return []
 
-    with source_file.open("r", encoding="utf-8", errors="replace") as handle:
-        lines = handle.readlines()
-    return frame_lines(source_file, lines, start_offset=0)
+    size = source_file.stat().st_size
+    offset = min(max(start_offset, 0), size)
+    with source_file.open("rb") as handle:
+        handle.seek(offset)
+        payload = handle.read()
+    text = payload.decode("utf-8", errors="replace")
+    lines = text.splitlines(keepends=True)
+    return frame_lines(source_file, lines, start_offset=offset)
 
 
 def read_new_segments(state: FollowState) -> tuple[list[RawSegment], bool]:

--- a/src/arena_companion/services/ingest_service.py
+++ b/src/arena_companion/services/ingest_service.py
@@ -3,6 +3,11 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 
+from arena_companion.db.repositories.ingest_checkpoints import (
+    delete_checkpoint,
+    load_checkpoint,
+    upsert_checkpoint,
+)
 from arena_companion.db.repositories.raw_segments import insert_raw_segments
 from arena_companion.ingest.log_discovery import LogPaths
 from arena_companion.ingest.log_follower import FollowState, read_new_segments, replay_file
@@ -21,13 +26,37 @@ class IngestService:
         self.db_path = db_path
         self.log_paths = log_paths
         self.stats = IngestStats()
-        self._live_state = FollowState(source_file=log_paths.current_log)
+        live_checkpoint = load_checkpoint(self.db_path, log_paths.current_log)
+        live_offset = live_checkpoint.last_offset if live_checkpoint else 0
+        self._live_state = FollowState(source_file=log_paths.current_log, offset=live_offset, last_size=live_offset)
+        self._live_last_segment_id = live_checkpoint.last_segment_id if live_checkpoint else None
 
-    def replay_previous_session(self) -> int:
-        segments = replay_file(self.log_paths.previous_log)
+    def replay_previous_session(self, force_full_replay: bool = False) -> int:
+        checkpoint = None if force_full_replay else load_checkpoint(self.db_path, self.log_paths.previous_log)
+        start_offset = checkpoint.last_offset if checkpoint else 0
+        if not self.log_paths.previous_log.exists():
+            if force_full_replay:
+                delete_checkpoint(self.db_path, self.log_paths.previous_log)
+            return 0
+
+        file_size = self.log_paths.previous_log.stat().st_size
+        if start_offset > file_size:
+            start_offset = 0
+            checkpoint = None
+
+        segments = replay_file(self.log_paths.previous_log, start_offset=start_offset)
         inserted = insert_raw_segments(self.db_path, segments)
         self.stats.replay_segments += len(segments)
         self.stats.deduped_segments += max(len(segments) - inserted, 0)
+        replay_last_segment_id = checkpoint.last_segment_id if checkpoint else None
+        if segments:
+            replay_last_segment_id = self._segment_id_for_offset(self.log_paths.previous_log, segments[-1].source_offset)
+        upsert_checkpoint(
+            self.db_path,
+            self.log_paths.previous_log,
+            file_size,
+            replay_last_segment_id,
+        )
         return inserted
 
     def ingest_live_once(self) -> int:
@@ -37,4 +66,34 @@ class IngestService:
         self.stats.deduped_segments += max(len(segments) - inserted, 0)
         if truncated:
             self.stats.truncation_events += 1
+        if segments:
+            self._live_last_segment_id = self._segment_id_for_offset(self.log_paths.current_log, segments[-1].source_offset)
+        upsert_checkpoint(
+            self.db_path,
+            self.log_paths.current_log,
+            self._live_state.offset,
+            self._live_last_segment_id,
+        )
         return inserted
+
+    def clear_replay_checkpoint(self) -> None:
+        delete_checkpoint(self.db_path, self.log_paths.previous_log)
+
+    def _segment_id_for_offset(self, source_file: Path, source_offset: int) -> int | None:
+        import sqlite3
+
+        conn = sqlite3.connect(self.db_path)
+        try:
+            row = conn.execute(
+                """
+                SELECT id
+                FROM raw_segments
+                WHERE source_file=? AND source_offset=?
+                ORDER BY id DESC
+                LIMIT 1
+                """,
+                (str(source_file), source_offset),
+            ).fetchone()
+            return int(row[0]) if row else None
+        finally:
+            conn.close()

--- a/tests/test_ingest_service.py
+++ b/tests/test_ingest_service.py
@@ -30,6 +30,8 @@ class IngestServiceTests(unittest.TestCase):
 
             replay_inserted = service.replay_previous_session()
             self.assertEqual(replay_inserted, 1)
+            replay_inserted_again = service.replay_previous_session()
+            self.assertEqual(replay_inserted_again, 0)
 
             live_inserted = service.ingest_live_once()
             self.assertEqual(live_inserted, 1)
@@ -41,9 +43,18 @@ class IngestServiceTests(unittest.TestCase):
             conn = sqlite3.connect(db_path)
             try:
                 count = conn.execute("SELECT COUNT(*) FROM raw_segments").fetchone()[0]
+                checkpoints = conn.execute(
+                    "SELECT source_file, last_offset, last_segment_id FROM ingest_checkpoints ORDER BY source_file"
+                ).fetchall()
             finally:
                 conn.close()
             self.assertEqual(count, 2)
+            self.assertEqual(len(checkpoints), 2)
+            checkpoint_map = {row[0]: (row[1], row[2]) for row in checkpoints}
+            self.assertEqual(checkpoint_map[str(previous)][0], previous.stat().st_size)
+            self.assertEqual(checkpoint_map[str(current)][0], current.stat().st_size)
+            self.assertIsNotNone(checkpoint_map[str(previous)][1])
+            self.assertIsNotNone(checkpoint_map[str(current)][1])
 
     def test_truncation_increments_stats(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -64,6 +75,61 @@ class IngestServiceTests(unittest.TestCase):
             service.ingest_live_once()
 
             self.assertGreaterEqual(service.stats.truncation_events, 1)
+
+    def test_force_full_replay_bypasses_checkpoint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            current = root / "Player.log"
+            previous = root / "Player-prev.log"
+            db_path = root / "arena_companion.db"
+
+            previous.write_text("prev-line\n", encoding="utf-8")
+            current.write_text("", encoding="utf-8")
+
+            apply_migrations(db_path)
+            service = IngestService(db_path, resolve_log_paths(str(root)))
+
+            inserted_first = service.replay_previous_session()
+            self.assertEqual(inserted_first, 1)
+            self.assertEqual(service.stats.replay_segments, 1)
+
+            inserted_forced = service.replay_previous_session(force_full_replay=True)
+            self.assertEqual(inserted_forced, 0)
+            # Force mode replays file from offset 0 even when dedupe ignores inserts.
+            self.assertEqual(service.stats.replay_segments, 2)
+
+    def test_replay_checkpoint_advances_only_for_new_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            current = root / "Player.log"
+            previous = root / "Player-prev.log"
+            db_path = root / "arena_companion.db"
+
+            previous.write_text("line-1\nline-2\n", encoding="utf-8")
+            current.write_text("", encoding="utf-8")
+
+            apply_migrations(db_path)
+            service = IngestService(db_path, resolve_log_paths(str(root)))
+
+            self.assertEqual(service.replay_previous_session(), 2)
+            self.assertEqual(service.replay_previous_session(), 0)
+
+            previous.write_text("line-1\nline-2\nline-3\n", encoding="utf-8")
+            self.assertEqual(service.replay_previous_session(), 1)
+
+            conn = sqlite3.connect(db_path)
+            try:
+                replay_checkpoint = conn.execute(
+                    "SELECT last_offset, last_segment_id FROM ingest_checkpoints WHERE source_file=?",
+                    (str(previous),),
+                ).fetchone()
+            finally:
+                conn.close()
+
+            self.assertIsNotNone(replay_checkpoint)
+            if replay_checkpoint is not None:
+                self.assertEqual(replay_checkpoint[0], previous.stat().st_size)
+                self.assertIsNotNone(replay_checkpoint[1])
 
 
 if __name__ == "__main__":

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -42,6 +42,7 @@ class MigrationTests(unittest.TestCase):
                 "turn_events",
                 "parser_errors",
                 "app_settings",
+                "ingest_checkpoints",
                 "collection_snapshots",
                 "collection_cards",
             }


### PR DESCRIPTION
## Summary
- add persisted ingest checkpoints (`source_file`, `last_offset`, `last_segment_id`) via migration `0003_ingest_checkpoints`
- update `IngestService` replay/live ingest to resume from stored offsets and update checkpoints after each run
- add force mode (`replay_previous_session(force_full_replay=True)`) to bypass checkpointed startup replay when full replay is requested
- add replay checkpoint benchmark script and report artifact with measured startup speedup

## Validation
- `python -m unittest discover -s tests -p test_*.py -v`
- `python scripts/benchmark_replay_checkpoint.py`

## Evidence
- benchmark report: `docs/benchmark_replay_checkpoint.json`
- performance summary: `docs/performance-baseline.md`

Closes #71