### PR TITLE
ci: harden workflows with python matrix and deterministic cache

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -9,8 +9,12 @@ on:
       - "v*"
 
 jobs:
-  tests:
+  tests_matrix:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13"]
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -18,11 +22,42 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            requirements-ci.txt
 
       - name: Run Unit Tests (ResourceWarning=error)
         run: |
           python -W error::ResourceWarning -m unittest discover -s tests -p "test_*.py" -v
+
+      - name: Matrix Summary
+        if: always()
+        run: |
+          echo "### Quality Gates Test Matrix" >> "$GITHUB_STEP_SUMMARY"
+          echo "- runner: ubuntu-latest" >> "$GITHUB_STEP_SUMMARY"
+          echo "- python: ${{ matrix.python-version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- result: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
+
+  tests:
+    runs-on: ubuntu-latest
+    needs:
+      - tests_matrix
+    steps:
+      - name: Validate matrix result
+        run: |
+          echo "Matrix result: ${{ needs.tests_matrix.result }}"
+          if [ "${{ needs.tests_matrix.result }}" != "success" ]; then
+            exit 1
+          fi
+
+      - name: Workflow Summary
+        run: |
+          echo "### Quality Gates Matrix Aggregate" >> "$GITHUB_STEP_SUMMARY"
+          echo "- matrix job: tests_matrix" >> "$GITHUB_STEP_SUMMARY"
+          echo "- aggregate result: ${{ needs.tests_matrix.result }}" >> "$GITHUB_STEP_SUMMARY"
 
   release_tag_build:
     if: startsWith(github.ref, 'refs/tags/v')
@@ -43,11 +78,14 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: |
+            requirements-ci.txt
 
       - name: Install Packaging Dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install pyinstaller
+          python -m pip install --requirement requirements-ci.txt
 
       - name: Install Inno Setup (Current User)
         run: |

--- a/.github/workflows/regression-suite.yml
+++ b/.github/workflows/regression-suite.yml
@@ -17,10 +17,23 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: |
+            pyproject.toml
+            requirements.txt
+            requirements-ci.txt
 
       - name: Run regression tests
         run: |
           python -m unittest tests/test_golden_harness.py tests/test_fixture_manifest.py -v
+
+      - name: Regression Summary
+        if: always()
+        run: |
+          echo "### Regression Suite" >> "$GITHUB_STEP_SUMMARY"
+          echo "- runner: ubuntu-latest" >> "$GITHUB_STEP_SUMMARY"
+          echo "- python: 3.13" >> "$GITHUB_STEP_SUMMARY"
+          echo "- result: ${{ job.status }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload regression artifacts
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -21,3 +21,13 @@ set PYTHONPATH=src && python -m arena_companion.main --print-paths
 - App bootstrap and `%APPDATA%\\ArenaCompanion` lifecycle.
 - SQLite migration runner with initial 1.0.0 schema.
 - Bundled offline `cards.sqlite` seed database.
+
+## CI Support Matrix
+
+- `Quality Gates` test matrix:
+  - `ubuntu-latest` + Python `3.12`
+  - `ubuntu-latest` + Python `3.13`
+- `Regression Suite`:
+  - `ubuntu-latest` + Python `3.13`
+- `release_tag_build` (tagged releases):
+  - `windows-latest` + Python `3.13`

--- a/requirements-ci.txt
+++ b/requirements-ci.txt
@@ -1,0 +1,2 @@
+# CI packaging dependencies (pinned for deterministic builds)
+pyinstaller==6.16.0


### PR DESCRIPTION
## Summary
- run Quality Gates unit tests against a Python matrix (`3.12`, `3.13`) while keeping a stable aggregate `tests` status check for branch protection
- add deterministic pip caching keyed on `pyproject.toml`, `requirements.txt`, and `requirements-ci.txt`
- pin CI packaging dependency in `requirements-ci.txt` and consume it in release tag build
- add workflow summary output so matrix failures/results are explicit in step summaries
- document supported CI runner/Python combinations in `README.md`

## Validation
- `python -m unittest discover -s tests -p test_*.py -v`

Closes #75