### PR TITLE
feat: add collection filters and trend panel support

### DIFF
--- a/src/arena_companion/services/collection_service.py
+++ b/src/arena_companion/services/collection_service.py
@@ -16,10 +16,15 @@ class CollectionService:
         self.db_path = db_path
         self._card_lookup = CardLookupService(cards_db_path) if cards_db_path is not None else None
 
-    def _card_name(self, arena_card_id: int) -> str:
+    def _card_metadata(self, arena_card_id: int) -> dict[str, str | int | None]:
         if self._card_lookup is None:
-            return f"Unknown Card ({arena_card_id})"
-        return self._card_lookup.lookup_name(arena_card_id)
+            return {
+                "arena_card_id": arena_card_id,
+                "name": f"Unknown Card ({arena_card_id})",
+                "set_code": None,
+                "rarity": None,
+            }
+        return self._card_lookup.lookup_metadata(arena_card_id)
 
     def list_snapshots(self, limit: int = 50) -> list[dict[str, Any]]:
         conn = _connect(self.db_path)
@@ -67,10 +72,13 @@ class CollectionService:
         cards: list[dict[str, Any]] = []
         for arena_card_id, quantity in rows:
             card_id = int(arena_card_id)
+            metadata = self._card_metadata(card_id)
             cards.append(
                 {
                     "arena_card_id": card_id,
-                    "card_name": self._card_name(card_id),
+                    "card_name": str(metadata["name"]),
+                    "set_code": metadata["set_code"],
+                    "rarity": metadata["rarity"],
                     "quantity": int(quantity),
                 }
             )
@@ -91,7 +99,14 @@ class CollectionService:
         older = int(rows[1][0])
         return (older, newer)
 
-    def diff_snapshots(self, from_snapshot_id: int, to_snapshot_id: int) -> list[dict[str, Any]]:
+    def diff_snapshots(
+        self,
+        from_snapshot_id: int,
+        to_snapshot_id: int,
+        set_code: str | None = None,
+        rarity: str | None = None,
+        delta_filter: str = "all",
+    ) -> list[dict[str, Any]]:
         conn = _connect(self.db_path)
         try:
             from_rows = conn.execute(
@@ -108,20 +123,84 @@ class CollectionService:
         from_map = {int(card_id): int(quantity) for card_id, quantity in from_rows}
         to_map = {int(card_id): int(quantity) for card_id, quantity in to_rows}
 
+        normalized_set = set_code.upper() if set_code else None
+        normalized_rarity = rarity.lower() if rarity else None
+        normalized_delta_filter = delta_filter.lower()
+        if normalized_delta_filter not in {"all", "gains", "losses"}:
+            raise ValueError("delta_filter must be one of: all, gains, losses")
+
         rows: list[dict[str, Any]] = []
         for arena_card_id in sorted(set(from_map).union(to_map)):
             quantity_from = from_map.get(arena_card_id, 0)
             quantity_to = to_map.get(arena_card_id, 0)
             if quantity_from == quantity_to:
                 continue
+            delta = quantity_to - quantity_from
+            if normalized_delta_filter == "gains" and delta <= 0:
+                continue
+            if normalized_delta_filter == "losses" and delta >= 0:
+                continue
+
+            metadata = self._card_metadata(arena_card_id)
+            metadata_set = str(metadata["set_code"]).upper() if metadata["set_code"] else None
+            metadata_rarity = str(metadata["rarity"]).lower() if metadata["rarity"] else None
+
+            if normalized_set and metadata_set != normalized_set:
+                continue
+            if normalized_rarity and metadata_rarity != normalized_rarity:
+                continue
             rows.append(
                 {
                     "arena_card_id": arena_card_id,
-                    "card_name": self._card_name(arena_card_id),
+                    "card_name": str(metadata["name"]),
+                    "set_code": metadata["set_code"],
+                    "rarity": metadata["rarity"],
                     "quantity_from": quantity_from,
                     "quantity_to": quantity_to,
-                    "delta": quantity_to - quantity_from,
+                    "delta": delta,
                 }
             )
 
         return rows
+
+    def trend_summary(self, limit_pairs: int = 5) -> list[dict[str, Any]]:
+        conn = _connect(self.db_path)
+        try:
+            rows = conn.execute(
+                """
+                SELECT id, captured_at
+                FROM collection_snapshots
+                ORDER BY id DESC
+                LIMIT ?
+                """,
+                (max(limit_pairs + 1, 2),),
+            ).fetchall()
+        finally:
+            conn.close()
+
+        if len(rows) < 2:
+            return []
+
+        trend_rows: list[dict[str, Any]] = []
+        for idx in range(min(limit_pairs, len(rows) - 1)):
+            newer_id = int(rows[idx][0])
+            newer_captured = str(rows[idx][1])
+            older_id = int(rows[idx + 1][0])
+            older_captured = str(rows[idx + 1][1])
+            diff_rows = self.diff_snapshots(older_id, newer_id)
+            gains = [row for row in diff_rows if int(row["delta"]) > 0]
+            losses = [row for row in diff_rows if int(row["delta"]) < 0]
+            trend_rows.append(
+                {
+                    "from_snapshot_id": older_id,
+                    "to_snapshot_id": newer_id,
+                    "from_captured_at": older_captured,
+                    "to_captured_at": newer_captured,
+                    "gained_cards": len(gains),
+                    "lost_cards": len(losses),
+                    "gained_quantity": sum(int(row["delta"]) for row in gains),
+                    "lost_quantity": sum(-int(row["delta"]) for row in losses),
+                    "net_delta": sum(int(row["delta"]) for row in diff_rows),
+                }
+            )
+        return trend_rows

--- a/src/arena_companion/ui/collection/view.py
+++ b/src/arena_companion/ui/collection/view.py
@@ -17,15 +17,31 @@ class CollectionSnapshotRow:
 class CollectionDiffRow:
     arena_card_id: int
     card_name: str
+    set_code: str | None
+    rarity: str | None
     quantity_from: int
     quantity_to: int
     delta: int
 
 
 @dataclass(frozen=True)
+class CollectionTrendRow:
+    from_snapshot_id: int
+    to_snapshot_id: int
+    from_captured_at: str
+    to_captured_at: str
+    gained_cards: int
+    lost_cards: int
+    gained_quantity: int
+    lost_quantity: int
+    net_delta: int
+
+
+@dataclass(frozen=True)
 class CollectionViewModel:
     snapshots: tuple[CollectionSnapshotRow, ...]
     diff_rows: tuple[CollectionDiffRow, ...]
+    trend_rows: tuple[CollectionTrendRow, ...]
     empty_state_message: str | None
     diagnostics_warning: str | None
 
@@ -33,17 +49,22 @@ class CollectionViewModel:
 def build_collection_view_model(
     snapshots: tuple[CollectionSnapshotRow, ...],
     diff_rows: tuple[CollectionDiffRow, ...],
+    trend_rows: tuple[CollectionTrendRow, ...] = (),
     diagnostics_warning: str | None = None,
+    filters_applied: bool = False,
 ) -> CollectionViewModel:
     empty_state_message = None
     if not snapshots:
         empty_state_message = "No collection snapshots available yet."
         if diagnostics_warning:
             empty_state_message = f"{empty_state_message} {diagnostics_warning}"
+    elif filters_applied and not diff_rows:
+        empty_state_message = "No collection changes match the active filters."
 
     return CollectionViewModel(
         snapshots=snapshots,
         diff_rows=diff_rows,
+        trend_rows=trend_rows,
         empty_state_message=empty_state_message,
         diagnostics_warning=diagnostics_warning,
     )

--- a/tests/test_collection_service.py
+++ b/tests/test_collection_service.py
@@ -35,6 +35,12 @@ def _seed_cards_db(path: Path) -> None:
             VALUES (67330, 'Plains', 'FDN', '276', 'common', 0, 'Basic Land - Plains', 0)
             """
         )
+        conn.execute(
+            """
+            INSERT INTO cards(arena_card_id, name, set_code, collector_number, rarity, mana_value, type_line, is_token)
+            VALUES (88888, 'Sunblade Angel', 'ANA', '1', 'rare', 6, 'Creature - Angel', 0)
+            """
+        )
         conn.commit()
     finally:
         conn.close()
@@ -105,11 +111,35 @@ class CollectionServiceTests(unittest.TestCase):
             self.assertEqual(diff[0]["arena_card_id"], 67330)
             self.assertEqual(diff[0]["delta"], 1)
             self.assertEqual(diff[0]["card_name"], "Plains")
+            self.assertEqual(diff[0]["set_code"], "FDN")
+            self.assertEqual(diff[0]["rarity"], "common")
             self.assertEqual(diff[1]["arena_card_id"], 77777)
             self.assertEqual(diff[1]["delta"], -2)
             self.assertIn("Unknown Card", diff[1]["card_name"])
             self.assertEqual(diff[2]["arena_card_id"], 88888)
             self.assertEqual(diff[2]["delta"], 2)
+            self.assertEqual(diff[2]["set_code"], "ANA")
+            self.assertEqual(diff[2]["rarity"], "rare")
+
+            gains_only = service.diff_snapshots(int(old_id), int(new_id), delta_filter="gains")
+            self.assertEqual([row["arena_card_id"] for row in gains_only], [67330, 88888])
+
+            losses_only = service.diff_snapshots(int(old_id), int(new_id), delta_filter="losses")
+            self.assertEqual([row["arena_card_id"] for row in losses_only], [77777])
+
+            set_filtered = service.diff_snapshots(int(old_id), int(new_id), set_code="ANA")
+            self.assertEqual([row["arena_card_id"] for row in set_filtered], [88888])
+
+            rarity_filtered = service.diff_snapshots(int(old_id), int(new_id), rarity="common")
+            self.assertEqual([row["arena_card_id"] for row in rarity_filtered], [67330])
+
+            trends = service.trend_summary(limit_pairs=3)
+            self.assertEqual(len(trends), 1)
+            self.assertEqual(trends[0]["from_snapshot_id"], int(old_id))
+            self.assertEqual(trends[0]["to_snapshot_id"], int(new_id))
+            self.assertEqual(trends[0]["gained_cards"], 2)
+            self.assertEqual(trends[0]["lost_cards"], 1)
+            self.assertEqual(trends[0]["net_delta"], 1)
 
 
 if __name__ == "__main__":

--- a/tests/test_collection_ui.py
+++ b/tests/test_collection_ui.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from arena_companion.ui.collection.view import (
     CollectionDiffRow,
     CollectionSnapshotRow,
+    CollectionTrendRow,
     build_collection_view_model,
 )
 
@@ -39,19 +40,56 @@ class CollectionUiTests(unittest.TestCase):
             CollectionDiffRow(
                 arena_card_id=67330,
                 card_name="Plains",
+                set_code="FDN",
+                rarity="common",
                 quantity_from=3,
                 quantity_to=4,
                 delta=1,
             ),
         )
+        trends = (
+            CollectionTrendRow(
+                from_snapshot_id=1,
+                to_snapshot_id=2,
+                from_captured_at="2026-03-27T16:00:00Z",
+                to_captured_at="2026-03-30T16:00:00Z",
+                gained_cards=1,
+                lost_cards=0,
+                gained_quantity=1,
+                lost_quantity=0,
+                net_delta=1,
+            ),
+        )
         view_model = build_collection_view_model(
             snapshots=snapshots,
             diff_rows=diff_rows,
+            trend_rows=trends,
             diagnostics_warning=None,
         )
         self.assertIsNone(view_model.empty_state_message)
         self.assertEqual(view_model.snapshots[0].snapshot_id, 2)
         self.assertEqual(view_model.diff_rows[0].delta, 1)
+        self.assertEqual(view_model.trend_rows[0].net_delta, 1)
+
+    def test_filtered_state_shows_filter_empty_message(self) -> None:
+        snapshots = (
+            CollectionSnapshotRow(
+                snapshot_id=2,
+                captured_at="2026-03-30T16:00:00Z",
+                source_kind="owned_cards_v2",
+                client_build="2026.3.30",
+                unique_cards=2,
+                total_cards=6,
+            ),
+        )
+        view_model = build_collection_view_model(
+            snapshots=snapshots,
+            diff_rows=(),
+            trend_rows=(),
+            diagnostics_warning=None,
+            filters_applied=True,
+        )
+        self.assertEqual(view_model.empty_state_message, "No collection changes match the active filters.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add collection diff filtering by set code, rarity, and ownership delta direction (`gains` / `losses`)
- add trend summary aggregation across recent snapshot pairs (gains/losses/net delta)
- extend collection UI view model with trend rows and filtered empty-state messaging
- keep collection export schema unchanged (`collection-export-v1` remains intact)
- add UI and service test coverage for empty, populated, and filtered states plus trend summaries

## Validation
- `python -m unittest discover -s tests -p test_collection_*.py -v`
- `python -m unittest discover -s tests -p test_*.py -v`

Closes #72