### PR TITLE
refactor: typed parser contracts and metadata persistence

### DIFF
--- a/docs/parsing-notes.md
+++ b/docs/parsing-notes.md
@@ -22,6 +22,12 @@ Track observed MTGA log message families and their planned parser ownership.
 - Bump parser version when behavior changes.
 - Reprocess from `raw_segments` after parser upgrades.
 
+## Contract Migration Notes (v1.2.0 / Issue #73)
+- Parser registry now emits typed event DTOs in `parsers.events` and still includes a dict payload for compatibility.
+- `ParserResult` includes `contract_version` (`v1` baseline) and DTO reference (`event`).
+- Normalization now persists parser contract metadata per segment in `normalized_event_contracts`.
+- Fallback behavior is unchanged: unknown segments remain retained (`family=unknown`) and still receive contract metadata for auditability.
+
 ## Fixture Traceability
 Document every new fixture set with:
 1. Capture scenario.

--- a/src/arena_companion/db/migrations/0004_normalized_event_contracts.sql
+++ b/src/arena_companion/db/migrations/0004_normalized_event_contracts.sql
@@ -1,0 +1,11 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS normalized_event_contracts (
+    raw_segment_id INTEGER PRIMARY KEY,
+    family TEXT NOT NULL,
+    contract_version TEXT NOT NULL,
+    applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(raw_segment_id) REFERENCES raw_segments(id)
+);
+
+COMMIT;

--- a/src/arena_companion/db/repositories/normalized.py
+++ b/src/arena_companion/db/repositories/normalized.py
@@ -242,7 +242,7 @@ def _insert_rank_snapshot(conn: sqlite3.Connection, payload: dict[str, Any]) -> 
 
 def _upsert_collection_snapshot(conn: sqlite3.Connection, payload: dict[str, Any], raw_segment_id: int) -> None:
     cards = payload.get("cards")
-    if not isinstance(cards, list):
+    if not isinstance(cards, (list, tuple)):
         return
 
     fingerprint = payload.get("snapshot_fingerprint")
@@ -331,6 +331,20 @@ def _record_parser_error(conn: sqlite3.Connection, parser_name: str, raw_segment
     )
 
 
+def _record_event_contract(conn: sqlite3.Connection, raw_segment_id: int, family: str, contract_version: str) -> None:
+    conn.execute(
+        """
+        INSERT INTO normalized_event_contracts(raw_segment_id, family, contract_version)
+        VALUES (?, ?, ?)
+        ON CONFLICT(raw_segment_id) DO UPDATE SET
+            family=excluded.family,
+            contract_version=excluded.contract_version,
+            applied_at=CURRENT_TIMESTAMP
+        """,
+        (raw_segment_id, family, contract_version),
+    )
+
+
 def apply_parser_result(db_path: Path, raw_segment_id: int, result: ParserResult) -> None:
     conn = _connect(db_path)
     try:
@@ -374,6 +388,7 @@ def apply_parser_result(db_path: Path, raw_segment_id: int, result: ParserResult
             "UPDATE raw_segments SET segment_type=?, parse_status=?, error_message=? WHERE id=?",
             (family, parse_status, error_message, raw_segment_id),
         )
+        _record_event_contract(conn, raw_segment_id, family, result.contract_version)
         conn.commit()
     finally:
         conn.close()

--- a/src/arena_companion/db/schema.sql
+++ b/src/arena_companion/db/schema.sql
@@ -161,6 +161,14 @@ CREATE TABLE IF NOT EXISTS ingest_checkpoints (
     FOREIGN KEY(last_segment_id) REFERENCES raw_segments(id)
 );
 
+CREATE TABLE IF NOT EXISTS normalized_event_contracts (
+    raw_segment_id INTEGER PRIMARY KEY,
+    family TEXT NOT NULL,
+    contract_version TEXT NOT NULL,
+    applied_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY(raw_segment_id) REFERENCES raw_segments(id)
+);
+
 CREATE TABLE IF NOT EXISTS collection_snapshots (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     captured_at TEXT NOT NULL,

--- a/src/arena_companion/parsers/base.py
+++ b/src/arena_companion/parsers/base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 from typing import Any
 
 
@@ -8,6 +8,18 @@ from typing import Any
 class ParserResult:
     family: str
     payload: dict[str, Any]
+    contract_version: str = "v1"
+    event: Any | None = None
+
+
+def parser_result_from_event(family: str, event: Any, contract_version: str = "v1") -> ParserResult:
+    if is_dataclass(event):
+        payload = asdict(event)
+    elif isinstance(event, dict):
+        payload = event
+    else:
+        raise TypeError("event must be a dataclass or dict payload")
+    return ParserResult(family=family, payload=payload, contract_version=contract_version, event=event)
 
 
 class SegmentParser:

--- a/src/arena_companion/parsers/collection.py
+++ b/src/arena_companion/parsers/collection.py
@@ -4,7 +4,8 @@ import hashlib
 import json
 from typing import Any
 
-from arena_companion.parsers.base import ParserResult, SegmentParser
+from arena_companion.parsers.base import ParserResult, SegmentParser, parser_result_from_event
+from arena_companion.parsers.events import CollectionCardEvent, CollectionParseErrorEvent, CollectionSnapshotEvent
 
 
 def _extract_json_payload(raw_text: str) -> dict[str, Any]:
@@ -70,6 +71,7 @@ def _compute_snapshot_fingerprint(
 
 class CollectionParser(SegmentParser):
     family = "collection_snapshot"
+    contract_version = "v1"
     _MARKER = "Collection.OwnedCardsSnapshot"
 
     def parse(self, raw_text: str) -> ParserResult | None:
@@ -84,36 +86,38 @@ class CollectionParser(SegmentParser):
 
             card_quantities = _to_card_quantity_map(raw_cards)
             cards = [
-                {"arena_card_id": arena_card_id, "quantity": quantity}
+                CollectionCardEvent(arena_card_id=arena_card_id, quantity=quantity)
                 for arena_card_id, quantity in sorted(card_quantities.items())
                 if quantity > 0
             ]
             if not cards:
                 raise ValueError("no cards with positive quantity")
+            canonical_cards = [{"arena_card_id": card.arena_card_id, "quantity": card.quantity} for card in cards]
 
             source_kind = str(payload.get("source_kind", payload.get("sourceKind", "owned_cards_snapshot")))
             parser_schema_version = str(payload.get("schema_version", payload.get("schemaVersion", "v1")))
             client_build_value = payload.get("client_build", payload.get("clientBuild"))
             client_build = str(client_build_value) if client_build_value is not None else None
-            fingerprint = _compute_snapshot_fingerprint(source_kind, parser_schema_version, client_build, cards)
-
-            return ParserResult(
-                family=self.family,
-                payload={
-                    "source_kind": source_kind,
-                    "parser_schema_version": parser_schema_version,
-                    "client_build": client_build,
-                    "snapshot_fingerprint": fingerprint,
-                    "unique_cards": len(cards),
-                    "total_cards": sum(card["quantity"] for card in cards),
-                    "cards": cards,
-                },
+            fingerprint = _compute_snapshot_fingerprint(
+                source_kind,
+                parser_schema_version,
+                client_build,
+                canonical_cards,
             )
+
+            event = CollectionSnapshotEvent(
+                source_kind=source_kind,
+                parser_schema_version=parser_schema_version,
+                client_build=client_build,
+                snapshot_fingerprint=fingerprint,
+                unique_cards=len(cards),
+                total_cards=sum(card.quantity for card in cards),
+                cards=tuple(cards),
+            )
+            return parser_result_from_event(self.family, event, contract_version=self.contract_version)
         except Exception as exc:
-            return ParserResult(
-                family="collection_parse_error",
-                payload={
-                    "parser_name": "collection",
-                    "error": str(exc),
-                },
+            return parser_result_from_event(
+                "collection_parse_error",
+                CollectionParseErrorEvent(parser_name="collection", error=str(exc)),
+                contract_version=self.contract_version,
             )

--- a/src/arena_companion/parsers/decks.py
+++ b/src/arena_companion/parsers/decks.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import re
 
-from arena_companion.parsers.base import ParserResult, SegmentParser
+from arena_companion.parsers.base import ParserResult, SegmentParser, parser_result_from_event
+from arena_companion.parsers.events import DeckSubmissionEvent
 
 
 _DECK_RE = re.compile(
@@ -12,16 +13,15 @@ _DECK_RE = re.compile(
 
 class DeckParser(SegmentParser):
     family = "deck_submission"
+    contract_version = "v1"
 
     def parse(self, raw_text: str) -> ParserResult | None:
         match = _DECK_RE.search(raw_text)
         if not match:
             return None
-        return ParserResult(
-            family=self.family,
-            payload={
-                "deck_name": match.group("deck_name"),
-                "format": match.group("format"),
-                "deck_fingerprint": match.group("fingerprint"),
-            },
+        event = DeckSubmissionEvent(
+            deck_name=match.group("deck_name"),
+            format=match.group("format"),
+            deck_fingerprint=match.group("fingerprint"),
         )
+        return parser_result_from_event(self.family, event, contract_version=self.contract_version)

--- a/src/arena_companion/parsers/events.py
+++ b/src/arena_companion/parsers/events.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MatchRoomEvent:
+    match_id: str
+    opponent_name: str
+
+
+@dataclass(frozen=True)
+class DeckSubmissionEvent:
+    deck_name: str
+    format: str
+    deck_fingerprint: str
+
+
+@dataclass(frozen=True)
+class ResultEvent:
+    result: str
+    reason: str | None
+
+
+@dataclass(frozen=True)
+class InventorySnapshotEvent:
+    gold: int
+    gems: int
+    wc_common: int
+    wc_uncommon: int
+    wc_rare: int
+    wc_mythic: int
+
+
+@dataclass(frozen=True)
+class GreEvent:
+    turn_number: int
+    event_type: str
+    arena_card_id: int | None
+    zone_from: str | None
+    zone_to: str | None
+
+
+@dataclass(frozen=True)
+class ObservedCardEvent:
+    opponent_name: str
+    arena_card_id: int
+    turn: int
+
+
+@dataclass(frozen=True)
+class RankSnapshotEvent:
+    player: str
+    mode: str
+    rank_class: str
+    rank_tier: str
+    rank_step: str
+
+
+@dataclass(frozen=True)
+class CollectionCardEvent:
+    arena_card_id: int
+    quantity: int
+
+
+@dataclass(frozen=True)
+class CollectionSnapshotEvent:
+    source_kind: str
+    parser_schema_version: str
+    client_build: str | None
+    snapshot_fingerprint: str
+    unique_cards: int
+    total_cards: int
+    cards: tuple[CollectionCardEvent, ...]
+
+
+@dataclass(frozen=True)
+class CollectionParseErrorEvent:
+    parser_name: str
+    error: str
+
+
+@dataclass(frozen=True)
+class UnknownEvent:
+    raw_text: str

--- a/src/arena_companion/parsers/gre.py
+++ b/src/arena_companion/parsers/gre.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import re
 
-from arena_companion.parsers.base import ParserResult, SegmentParser
+from arena_companion.parsers.base import ParserResult, SegmentParser, parser_result_from_event
+from arena_companion.parsers.events import GreEvent
 
 
 _GRE_RE = re.compile(
@@ -12,18 +13,17 @@ _GRE_RE = re.compile(
 
 class GreParser(SegmentParser):
     family = "gre_event"
+    contract_version = "v1"
 
     def parse(self, raw_text: str) -> ParserResult | None:
         match = _GRE_RE.search(raw_text)
         if not match:
             return None
-        return ParserResult(
-            family=self.family,
-            payload={
-                "turn_number": int(match.group("turn")),
-                "event_type": match.group("event"),
-                "arena_card_id": int(match.group("card")) if match.group("card") else None,
-                "zone_from": match.group("zone_from"),
-                "zone_to": match.group("zone_to"),
-            },
+        event = GreEvent(
+            turn_number=int(match.group("turn")),
+            event_type=match.group("event"),
+            arena_card_id=int(match.group("card")) if match.group("card") else None,
+            zone_from=match.group("zone_from"),
+            zone_to=match.group("zone_to"),
         )
+        return parser_result_from_event(self.family, event, contract_version=self.contract_version)

--- a/src/arena_companion/parsers/inventory.py
+++ b/src/arena_companion/parsers/inventory.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import re
 
-from arena_companion.parsers.base import ParserResult, SegmentParser
+from arena_companion.parsers.base import ParserResult, SegmentParser, parser_result_from_event
+from arena_companion.parsers.events import InventorySnapshotEvent
 
 
 _INVENTORY_RE = re.compile(
@@ -12,19 +13,18 @@ _INVENTORY_RE = re.compile(
 
 class InventoryParser(SegmentParser):
     family = "inventory"
+    contract_version = "v1"
 
     def parse(self, raw_text: str) -> ParserResult | None:
         match = _INVENTORY_RE.search(raw_text)
         if not match:
             return None
-        return ParserResult(
-            family=self.family,
-            payload={
-                "gold": int(match.group("gold")),
-                "gems": int(match.group("gems")),
-                "wc_common": int(match.group("wc_common")),
-                "wc_uncommon": int(match.group("wc_uncommon")),
-                "wc_rare": int(match.group("wc_rare")),
-                "wc_mythic": int(match.group("wc_mythic")),
-            },
+        event = InventorySnapshotEvent(
+            gold=int(match.group("gold")),
+            gems=int(match.group("gems")),
+            wc_common=int(match.group("wc_common")),
+            wc_uncommon=int(match.group("wc_uncommon")),
+            wc_rare=int(match.group("wc_rare")),
+            wc_mythic=int(match.group("wc_mythic")),
         )
+        return parser_result_from_event(self.family, event, contract_version=self.contract_version)

--- a/src/arena_companion/parsers/matches.py
+++ b/src/arena_companion/parsers/matches.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import re
 
-from arena_companion.parsers.base import ParserResult, SegmentParser
+from arena_companion.parsers.base import ParserResult, SegmentParser, parser_result_from_event
+from arena_companion.parsers.events import MatchRoomEvent
 
 
 _MATCH_RE = re.compile(r"Event\.MatchCreated\s+matchId=(?P<match_id>[^\s]+)(?:\s+opponentName=(?P<opponent>[^\s]+))?")
@@ -10,15 +11,14 @@ _MATCH_RE = re.compile(r"Event\.MatchCreated\s+matchId=(?P<match_id>[^\s]+)(?:\s
 
 class MatchParser(SegmentParser):
     family = "match_room"
+    contract_version = "v1"
 
     def parse(self, raw_text: str) -> ParserResult | None:
         match = _MATCH_RE.search(raw_text)
         if not match:
             return None
-        return ParserResult(
-            family=self.family,
-            payload={
-                "match_id": match.group("match_id"),
-                "opponent_name": match.group("opponent") or "UnknownOpponent",
-            },
+        event = MatchRoomEvent(
+            match_id=match.group("match_id"),
+            opponent_name=match.group("opponent") or "UnknownOpponent",
         )
+        return parser_result_from_event(self.family, event, contract_version=self.contract_version)

--- a/src/arena_companion/parsers/observed_cards.py
+++ b/src/arena_companion/parsers/observed_cards.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import re
 
-from arena_companion.parsers.base import ParserResult, SegmentParser
+from arena_companion.parsers.base import ParserResult, SegmentParser, parser_result_from_event
+from arena_companion.parsers.events import ObservedCardEvent
 
 
 _OBSERVED_RE = re.compile(
@@ -12,16 +13,15 @@ _OBSERVED_RE = re.compile(
 
 class ObservedCardParser(SegmentParser):
     family = "observed_card"
+    contract_version = "v1"
 
     def parse(self, raw_text: str) -> ParserResult | None:
         match = _OBSERVED_RE.search(raw_text)
         if not match:
             return None
-        return ParserResult(
-            family=self.family,
-            payload={
-                "opponent_name": match.group("opponent"),
-                "arena_card_id": int(match.group("card")),
-                "turn": int(match.group("turn")),
-            },
+        event = ObservedCardEvent(
+            opponent_name=match.group("opponent"),
+            arena_card_id=int(match.group("card")),
+            turn=int(match.group("turn")),
         )
+        return parser_result_from_event(self.family, event, contract_version=self.contract_version)

--- a/src/arena_companion/parsers/ranks.py
+++ b/src/arena_companion/parsers/ranks.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import re
 
-from arena_companion.parsers.base import ParserResult, SegmentParser
+from arena_companion.parsers.base import ParserResult, SegmentParser, parser_result_from_event
+from arena_companion.parsers.events import RankSnapshotEvent
 
 
 _RANK_RE = re.compile(
@@ -12,18 +13,17 @@ _RANK_RE = re.compile(
 
 class RankParser(SegmentParser):
     family = "rank_snapshot"
+    contract_version = "v1"
 
     def parse(self, raw_text: str) -> ParserResult | None:
         match = _RANK_RE.search(raw_text)
         if not match:
             return None
-        return ParserResult(
-            family=self.family,
-            payload={
-                "player": match.group("player"),
-                "mode": match.group("mode"),
-                "rank_class": match.group("rank_class"),
-                "rank_tier": match.group("tier"),
-                "rank_step": match.group("step"),
-            },
+        event = RankSnapshotEvent(
+            player=match.group("player"),
+            mode=match.group("mode"),
+            rank_class=match.group("rank_class"),
+            rank_tier=match.group("tier"),
+            rank_step=match.group("step"),
         )
+        return parser_result_from_event(self.family, event, contract_version=self.contract_version)

--- a/src/arena_companion/parsers/registry.py
+++ b/src/arena_companion/parsers/registry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from arena_companion.parsers.base import ParserResult, SegmentParser
+from arena_companion.parsers.base import ParserResult, SegmentParser, parser_result_from_event
+from arena_companion.parsers.events import UnknownEvent
 from arena_companion.parsers.collection import CollectionParser
 from arena_companion.parsers.decks import DeckParser
 from arena_companion.parsers.gre import GreParser
@@ -29,4 +30,4 @@ class ParserRegistry:
             parsed = parser.parse(raw_text)
             if parsed is not None:
                 return parsed
-        return ParserResult(family="unknown", payload={"raw_text": raw_text})
+        return parser_result_from_event("unknown", UnknownEvent(raw_text=raw_text), contract_version="v1")

--- a/src/arena_companion/parsers/results.py
+++ b/src/arena_companion/parsers/results.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import re
 
-from arena_companion.parsers.base import ParserResult, SegmentParser
+from arena_companion.parsers.base import ParserResult, SegmentParser, parser_result_from_event
+from arena_companion.parsers.events import ResultEvent
 
 
 _RESULT_RE = re.compile(r"Event\.GameEnded\s+result=(?P<result>[^\s]+)(?:\s+reason=(?P<reason>[^\s]+))?")
@@ -10,15 +11,14 @@ _RESULT_RE = re.compile(r"Event\.GameEnded\s+result=(?P<result>[^\s]+)(?:\s+reas
 
 class ResultParser(SegmentParser):
     family = "results"
+    contract_version = "v1"
 
     def parse(self, raw_text: str) -> ParserResult | None:
         match = _RESULT_RE.search(raw_text)
         if not match:
             return None
-        return ParserResult(
-            family=self.family,
-            payload={
-                "result": match.group("result"),
-                "reason": match.group("reason"),
-            },
+        event = ResultEvent(
+            result=match.group("result"),
+            reason=match.group("reason"),
         )
+        return parser_result_from_event(self.family, event, contract_version=self.contract_version)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -43,6 +43,7 @@ class MigrationTests(unittest.TestCase):
                 "parser_errors",
                 "app_settings",
                 "ingest_checkpoints",
+                "normalized_event_contracts",
                 "collection_snapshots",
                 "collection_cards",
             }

--- a/tests/test_parser_pipeline.py
+++ b/tests/test_parser_pipeline.py
@@ -40,6 +40,10 @@ class ParserPipelineTests(unittest.TestCase):
                 collection_snapshots = conn.execute("SELECT COUNT(*) FROM collection_snapshots").fetchone()[0]
                 collection_cards = conn.execute("SELECT COUNT(*) FROM collection_cards").fetchone()[0]
                 parser_errors = conn.execute("SELECT COUNT(*) FROM parser_errors").fetchone()[0]
+                contracts = conn.execute("SELECT COUNT(*) FROM normalized_event_contracts").fetchone()[0]
+                contract_versions = {
+                    row[0] for row in conn.execute("SELECT DISTINCT contract_version FROM normalized_event_contracts").fetchall()
+                }
                 parsed = conn.execute("SELECT COUNT(*) FROM raw_segments WHERE parse_status='parsed'").fetchone()[0]
                 unknown = conn.execute("SELECT COUNT(*) FROM raw_segments WHERE parse_status='unknown'").fetchone()[0]
                 errors = conn.execute("SELECT COUNT(*) FROM raw_segments WHERE parse_status='error'").fetchone()[0]
@@ -51,6 +55,8 @@ class ParserPipelineTests(unittest.TestCase):
             self.assertEqual(collection_snapshots, 1)
             self.assertEqual(collection_cards, 2)
             self.assertEqual(parser_errors, 1)
+            self.assertEqual(contracts, 5)
+            self.assertEqual(contract_versions, {"v1"})
             self.assertEqual(parsed, 4)
             self.assertEqual(unknown, 0)
             self.assertEqual(errors, 1)

--- a/tests/test_parser_registry.py
+++ b/tests/test_parser_registry.py
@@ -7,6 +7,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 
 from arena_companion.parsers.registry import ParserRegistry
+from arena_companion.parsers.events import InventorySnapshotEvent, MatchRoomEvent
 
 
 class ParserRegistryTests(unittest.TestCase):
@@ -15,6 +16,8 @@ class ParserRegistryTests(unittest.TestCase):
         result = registry.classify_and_parse("Event.MatchCreated matchId=match_1 opponentName=Bob")
         self.assertEqual(result.family, "match_room")
         self.assertEqual(result.payload["match_id"], "match_1")
+        self.assertEqual(result.contract_version, "v1")
+        self.assertIsInstance(result.event, MatchRoomEvent)
 
     def test_classifies_inventory_family(self) -> None:
         registry = ParserRegistry()
@@ -23,11 +26,13 @@ class ParserRegistryTests(unittest.TestCase):
         )
         self.assertEqual(result.family, "inventory")
         self.assertEqual(result.payload["gold"], 100)
+        self.assertIsInstance(result.event, InventorySnapshotEvent)
 
     def test_unknown_fallback(self) -> None:
         registry = ParserRegistry()
         result = registry.classify_and_parse("totally_unknown_payload")
         self.assertEqual(result.family, "unknown")
+        self.assertEqual(result.contract_version, "v1")
 
     def test_classifies_collection_snapshot_family(self) -> None:
         registry = ParserRegistry()
@@ -36,6 +41,7 @@ class ParserRegistryTests(unittest.TestCase):
         )
         self.assertEqual(result.family, "collection_snapshot")
         self.assertEqual(result.payload["unique_cards"], 2)
+        self.assertIsNotNone(result.event)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- introduce typed parser event DTOs (`parsers.events`) and emit them via `ParserResult.event`
- preserve compatibility with existing normalization by retaining dict payloads derived from DTOs
- add parser contract version metadata to `ParserResult` and persist it in `normalized_event_contracts`
- add migration `0004_normalized_event_contracts` and schema updates
- document parser contract migration/fallback behavior in `docs/parsing-notes.md`
- extend parser pipeline and registry tests to validate contract metadata persistence and typed events

## Validation
- `python -m unittest discover -s tests -p test_parser_*.py -v`
- `python -m unittest discover -s tests -p test_*.py -v`

Closes #73