### PR TITLE
feat: add db maintenance workflow and retention policies

### DIFF
--- a/scripts/db_maintenance.py
+++ b/scripts/db_maintenance.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from arena_companion.services.db_maintenance_service import DbMaintenanceService, RetentionPolicy
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Run Arena Companion SQLite maintenance")
+    parser.add_argument("--db-path", required=True, type=Path, help="Path to arena_companion.db")
+    parser.add_argument("--vacuum", action="store_true", help="Run VACUUM after ANALYZE")
+    parser.add_argument("--max-raw-segments", type=int, default=None, help="Retention limit for raw_segments")
+    parser.add_argument(
+        "--max-collection-snapshots",
+        type=int,
+        default=None,
+        help="Retention limit for collection_snapshots",
+    )
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    policy = RetentionPolicy(
+        max_raw_segments=args.max_raw_segments,
+        max_collection_snapshots=args.max_collection_snapshots,
+    )
+    result = DbMaintenanceService(args.db_path).run(
+        perform_vacuum=args.vacuum,
+        retention_policy=policy,
+    )
+    for line in result.log_lines:
+        print(line)
+    print(
+        f"Maintenance complete. pruned_raw_segments={result.pruned_raw_segments} "
+        f"pruned_collection_snapshots={result.pruned_collection_snapshots}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/arena_companion/services/db_maintenance_service.py
+++ b/src/arena_companion/services/db_maintenance_service.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+
+@dataclass(frozen=True)
+class RetentionPolicy:
+    max_raw_segments: int | None = None
+    max_collection_snapshots: int | None = None
+
+
+@dataclass(frozen=True)
+class MaintenanceResult:
+    analyzed: bool
+    vacuumed: bool
+    pruned_raw_segments: int
+    pruned_collection_snapshots: int
+    log_lines: tuple[str, ...]
+
+
+class DbMaintenanceService:
+    def __init__(
+        self,
+        db_path: Path,
+        live_tail_active_provider: Callable[[], bool] | None = None,
+    ) -> None:
+        self.db_path = db_path
+        self._live_tail_active_provider = live_tail_active_provider or (lambda: False)
+
+    def run(self, perform_vacuum: bool = False, retention_policy: RetentionPolicy | None = None) -> MaintenanceResult:
+        if self._live_tail_active_provider():
+            raise RuntimeError("Database maintenance is disabled while live tail ingest is active.")
+
+        policy = retention_policy or RetentionPolicy()
+        log_lines: list[str] = []
+        pruned_raw = 0
+        pruned_snapshots = 0
+        conn = None
+        try:
+            conn = sqlite3.connect(self.db_path, timeout=1.0)
+            conn.execute("PRAGMA foreign_keys=ON;")
+            log_lines.append("Starting ANALYZE.")
+            conn.execute("ANALYZE")
+            log_lines.append("ANALYZE completed.")
+
+            if policy.max_raw_segments is not None:
+                removed = _prune_raw_segments(conn, policy.max_raw_segments)
+                pruned_raw += removed
+                log_lines.append(f"Retention(raw_segments): removed {removed} row(s).")
+
+            if policy.max_collection_snapshots is not None:
+                removed = _prune_collection_snapshots(conn, policy.max_collection_snapshots)
+                pruned_snapshots += removed
+                log_lines.append(f"Retention(collection_snapshots): removed {removed} row(s).")
+
+            conn.commit()
+
+            if perform_vacuum:
+                log_lines.append("Starting VACUUM.")
+                conn.execute("VACUUM")
+                log_lines.append("VACUUM completed.")
+                conn.commit()
+
+            return MaintenanceResult(
+                analyzed=True,
+                vacuumed=perform_vacuum,
+                pruned_raw_segments=pruned_raw,
+                pruned_collection_snapshots=pruned_snapshots,
+                log_lines=tuple(log_lines),
+            )
+        except sqlite3.OperationalError as exc:
+            raise RuntimeError(f"Database maintenance failed: {exc}") from exc
+        finally:
+            if conn is not None:
+                conn.close()
+
+
+def _prune_collection_snapshots(conn: sqlite3.Connection, max_snapshots: int) -> int:
+    if max_snapshots < 0:
+        raise ValueError("max_collection_snapshots must be >= 0")
+    count = int(conn.execute("SELECT COUNT(*) FROM collection_snapshots").fetchone()[0])
+    overflow = count - max_snapshots
+    if overflow <= 0:
+        return 0
+
+    ids = [
+        int(row[0])
+        for row in conn.execute(
+            "SELECT id FROM collection_snapshots ORDER BY id ASC LIMIT ?",
+            (overflow,),
+        ).fetchall()
+    ]
+    if not ids:
+        return 0
+
+    placeholders = ",".join("?" for _ in ids)
+    conn.execute(
+        f"DELETE FROM collection_cards WHERE collection_snapshot_id IN ({placeholders})",
+        ids,
+    )
+    deleted = conn.execute(
+        f"DELETE FROM collection_snapshots WHERE id IN ({placeholders})",
+        ids,
+    ).rowcount
+    return int(deleted)
+
+
+def _prune_raw_segments(conn: sqlite3.Connection, max_segments: int) -> int:
+    if max_segments < 0:
+        raise ValueError("max_raw_segments must be >= 0")
+    count = int(conn.execute("SELECT COUNT(*) FROM raw_segments").fetchone()[0])
+    overflow = count - max_segments
+    if overflow <= 0:
+        return 0
+
+    rows = conn.execute(
+        """
+        SELECT rs.id
+        FROM raw_segments rs
+        LEFT JOIN inventory_snapshots inv ON inv.raw_segment_id=rs.id
+        LEFT JOIN collection_snapshots cs ON cs.raw_segment_id=rs.id
+        LEFT JOIN matches m_start ON m_start.raw_start_segment_id=rs.id
+        LEFT JOIN matches m_end ON m_end.raw_end_segment_id=rs.id
+        LEFT JOIN turn_events te ON te.raw_segment_id=rs.id
+        LEFT JOIN parser_errors pe ON pe.raw_segment_id=rs.id
+        LEFT JOIN normalized_event_contracts nec ON nec.raw_segment_id=rs.id
+        WHERE inv.id IS NULL
+          AND cs.id IS NULL
+          AND m_start.id IS NULL
+          AND m_end.id IS NULL
+          AND te.id IS NULL
+          AND pe.id IS NULL
+          AND nec.raw_segment_id IS NULL
+        ORDER BY rs.id ASC
+        LIMIT ?
+        """,
+        (overflow,),
+    ).fetchall()
+    ids = [int(row[0]) for row in rows]
+    if not ids:
+        return 0
+
+    placeholders = ",".join("?" for _ in ids)
+    deleted = conn.execute(f"DELETE FROM raw_segments WHERE id IN ({placeholders})", ids).rowcount
+    return int(deleted)

--- a/src/arena_companion/services/ingest_service.py
+++ b/src/arena_companion/services/ingest_service.py
@@ -26,6 +26,7 @@ class IngestService:
         self.db_path = db_path
         self.log_paths = log_paths
         self.stats = IngestStats()
+        self._live_tail_active = False
         live_checkpoint = load_checkpoint(self.db_path, log_paths.current_log)
         live_offset = live_checkpoint.last_offset if live_checkpoint else 0
         self._live_state = FollowState(source_file=log_paths.current_log, offset=live_offset, last_size=live_offset)
@@ -60,24 +61,34 @@ class IngestService:
         return inserted
 
     def ingest_live_once(self) -> int:
-        segments, truncated = read_new_segments(self._live_state)
-        inserted = insert_raw_segments(self.db_path, segments)
-        self.stats.live_segments += len(segments)
-        self.stats.deduped_segments += max(len(segments) - inserted, 0)
-        if truncated:
-            self.stats.truncation_events += 1
-        if segments:
-            self._live_last_segment_id = self._segment_id_for_offset(self.log_paths.current_log, segments[-1].source_offset)
-        upsert_checkpoint(
-            self.db_path,
-            self.log_paths.current_log,
-            self._live_state.offset,
-            self._live_last_segment_id,
-        )
-        return inserted
+        self._live_tail_active = True
+        try:
+            segments, truncated = read_new_segments(self._live_state)
+            inserted = insert_raw_segments(self.db_path, segments)
+            self.stats.live_segments += len(segments)
+            self.stats.deduped_segments += max(len(segments) - inserted, 0)
+            if truncated:
+                self.stats.truncation_events += 1
+            if segments:
+                self._live_last_segment_id = self._segment_id_for_offset(
+                    self.log_paths.current_log,
+                    segments[-1].source_offset,
+                )
+            upsert_checkpoint(
+                self.db_path,
+                self.log_paths.current_log,
+                self._live_state.offset,
+                self._live_last_segment_id,
+            )
+            return inserted
+        finally:
+            self._live_tail_active = False
 
     def clear_replay_checkpoint(self) -> None:
         delete_checkpoint(self.db_path, self.log_paths.previous_log)
+
+    def is_live_tail_active(self) -> bool:
+        return self._live_tail_active
 
     def _segment_id_for_offset(self, source_file: Path, source_offset: int) -> int | None:
         import sqlite3

--- a/tests/test_db_maintenance.py
+++ b/tests/test_db_maintenance.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from arena_companion.db.connection import apply_migrations
+from arena_companion.services.db_maintenance_service import DbMaintenanceService, RetentionPolicy
+
+
+def _seed_raw_segments(conn: sqlite3.Connection, count: int) -> None:
+    for idx in range(count):
+        conn.execute(
+            """
+            INSERT INTO raw_segments(
+                source_file, source_offset, captured_at, segment_type, parser_version, raw_text, raw_json, parse_status, error_message
+            ) VALUES (?, ?, CURRENT_TIMESTAMP, 'text', '0.1.0', ?, NULL, 'unclassified', NULL)
+            """,
+            ("Player.log", idx, f"line-{idx}"),
+        )
+
+
+def _seed_collection_snapshots(conn: sqlite3.Connection, count: int) -> None:
+    for idx in range(count):
+        fingerprint = f"fp-{idx}"
+        conn.execute(
+            """
+            INSERT INTO collection_snapshots(
+                captured_at, source_kind, raw_segment_id, snapshot_fingerprint, parser_schema_version, client_build, unique_cards, total_cards
+            ) VALUES (CURRENT_TIMESTAMP, 'owned_cards_v2', NULL, ?, 'v1', '2026.3.30', 1, 4)
+            """,
+            (fingerprint,),
+        )
+        snapshot_id = int(
+            conn.execute(
+                "SELECT id FROM collection_snapshots WHERE snapshot_fingerprint=?",
+                (fingerprint,),
+            ).fetchone()[0]
+        )
+        conn.execute(
+            "INSERT INTO collection_cards(collection_snapshot_id, arena_card_id, quantity) VALUES (?, 67330, 4)",
+            (snapshot_id,),
+        )
+
+
+class DbMaintenanceServiceTests(unittest.TestCase):
+    def test_retention_and_idempotency(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "arena_companion.db"
+            apply_migrations(db_path)
+
+            conn = sqlite3.connect(db_path)
+            try:
+                _seed_raw_segments(conn, count=10)
+                _seed_collection_snapshots(conn, count=3)
+                conn.commit()
+            finally:
+                conn.close()
+
+            service = DbMaintenanceService(db_path)
+            policy = RetentionPolicy(max_raw_segments=4, max_collection_snapshots=2)
+
+            first = service.run(perform_vacuum=True, retention_policy=policy)
+            self.assertTrue(first.analyzed)
+            self.assertTrue(first.vacuumed)
+            self.assertEqual(first.pruned_raw_segments, 6)
+            self.assertEqual(first.pruned_collection_snapshots, 1)
+            self.assertIn("ANALYZE completed.", first.log_lines)
+            self.assertIn("VACUUM completed.", first.log_lines)
+
+            conn = sqlite3.connect(db_path)
+            try:
+                raw_count = int(conn.execute("SELECT COUNT(*) FROM raw_segments").fetchone()[0])
+                snapshot_count = int(conn.execute("SELECT COUNT(*) FROM collection_snapshots").fetchone()[0])
+            finally:
+                conn.close()
+            self.assertEqual(raw_count, 4)
+            self.assertEqual(snapshot_count, 2)
+
+            second = service.run(perform_vacuum=False, retention_policy=policy)
+            self.assertTrue(second.analyzed)
+            self.assertFalse(second.vacuumed)
+            self.assertEqual(second.pruned_raw_segments, 0)
+            self.assertEqual(second.pruned_collection_snapshots, 0)
+
+    def test_live_tail_guard_blocks_maintenance(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "arena_companion.db"
+            apply_migrations(db_path)
+
+            service = DbMaintenanceService(db_path, live_tail_active_provider=lambda: True)
+            with self.assertRaises(RuntimeError):
+                service.run()
+
+    def test_lock_handling_raises_runtime_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            db_path = Path(tmp) / "arena_companion.db"
+            apply_migrations(db_path)
+
+            lock_conn = sqlite3.connect(db_path)
+            try:
+                lock_conn.execute("BEGIN EXCLUSIVE")
+                lock_conn.execute("CREATE TABLE IF NOT EXISTS maintenance_lock_sentinel(id INTEGER)")
+
+                service = DbMaintenanceService(db_path)
+                with self.assertRaises(RuntimeError) as ctx:
+                    service.run()
+                self.assertIn("locked", str(ctx.exception).lower())
+            finally:
+                lock_conn.rollback()
+                lock_conn.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `DbMaintenanceService` with progress logging for `ANALYZE` and optional `VACUUM`
- add retention policy hooks to prune old `raw_segments` and `collection_snapshots`
- add maintenance safety gate that blocks execution while live tail ingest is active
- add CLI command `scripts/db_maintenance.py` for explicit maintenance runs
- add tests for lock handling, idempotency, and live-tail guard behavior

## Validation
- `python -m unittest discover -s tests -p test_db_maintenance.py -v`
- `python -m unittest discover -s tests -p test_*.py -v`

Closes #74