### PR TITLE
docs: add rollback and compromised-release runbook

### DIFF
--- a/docs/code-signing.md
+++ b/docs/code-signing.md
@@ -25,3 +25,12 @@ powershell -ExecutionPolicy Bypass -File scripts/sign_artifacts.ps1 `
 ## Notes
 - `signtool.exe` must be available (in PATH or Windows SDK path).
 - Timestamping defaults to `http://timestamp.digicert.com`.
+
+## Key Rotation and Secret Revocation
+1. Revoke compromised certificate with your certificate authority.
+2. Delete compromised repository secrets:
+   - `WINDOWS_SIGN_CERT_PFX_BASE64`
+   - `WINDOWS_SIGN_CERT_PASSWORD`
+3. Generate/import replacement signing certificate (`.pfx`).
+4. Upload replacement secrets in repository settings.
+5. Run a signed-tag smoke build and verify Authenticode status before publishing the next release.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -23,6 +23,8 @@
 - [x] `main` branch protection policy includes required checks and review gates.
 - [x] Branch protection conformance workflow enabled:
   - `.github/workflows/branch-protection-conformance.yml`
+- [x] Rollback/compromised-tag runbook maintained:
+  - `docs/release-rollback-runbook.md`
 
 ## Evidence
 - Unit tests: `python -m unittest discover -s tests -p "test_*.py" -v` (38 passed).
@@ -30,5 +32,6 @@
 - Installer lifecycle evidence: `docs/installer-validation-results.md`
 - Performance baseline: `docs/performance-baseline.md`
 - Distribution notes: `docs/distribution-notes.md`
+- Rollback runbook: `docs/release-rollback-runbook.md`
 - Release tag: `v1.0.0`
 - GitHub release: `https://github.com/damon-heath/MTGA_Companion_App/releases/tag/v1.0.0`

--- a/docs/release-rollback-runbook.md
+++ b/docs/release-rollback-runbook.md
@@ -1,0 +1,57 @@
+# Release Rollback and Compromised-Tag Runbook
+
+## Scope
+Use this runbook when a published release/tag must be withdrawn due to bad artifacts, checksum/signature mismatch, or credential/signing compromise.
+
+## 1. Immediate Containment
+1. Pause distribution links (README, website, chat announcements).
+2. Stop new downloads by deleting the GitHub release:
+   - `gh release delete <tag> --repo damon-heath/MTGA_Companion_App --yes`
+3. If the tag itself is compromised, delete the remote tag:
+   - `git push origin :refs/tags/<tag>`
+
+## 2. Incident Classification
+- **Packaging defect only**: binaries are wrong but no credential compromise.
+- **Integrity failure**: published checksums/signatures no longer match.
+- **Credential compromise**: signing key or release token potentially exposed.
+
+## 3. Tag and Replacement Strategy
+1. Never reuse a withdrawn semantic version tag.
+2. Create a replacement patch tag (`vX.Y.(Z+1)`).
+3. Publish replacement release with clear note that prior tag was revoked.
+4. Add revoked-tag details to release notes:
+   - revoked tag id
+   - reason for revocation
+   - timestamp and replacement tag
+
+## 4. Checksum/Signature Invalidation Notice Template
+Use this text in GitHub release notes, issue announcement, and team channels.
+
+```text
+Security Notice: Release <revoked_tag> is revoked as of <timestamp_utc>.
+
+Reason: <brief reason>.
+Impact: Do not install or run artifacts from <revoked_tag>.
+Integrity: Previous checksums/signatures for <revoked_tag> are no longer trusted.
+Replacement: Use <replacement_tag> at <replacement_release_url>.
+Action Required: Delete downloaded artifacts from <revoked_tag> and redownload from <replacement_tag>.
+```
+
+## 5. Signing Key Rotation and Secret Revocation
+Follow the detailed steps in:
+- `docs/code-signing.md` (`Key Rotation and Secret Revocation` section)
+
+Minimum required actions:
+1. Revoke the compromised certificate with the certificate authority.
+2. Remove compromised GitHub secrets:
+   - `WINDOWS_SIGN_CERT_PFX_BASE64`
+   - `WINDOWS_SIGN_CERT_PASSWORD`
+3. Generate/import replacement signing certificate.
+4. Upload replacement secrets.
+5. Run signed-tag smoke (`Quality Gates` on test tag) before publishing replacement release.
+
+## 6. Post-Incident Verification
+1. Re-run release smoke validation workflow for replacement tag.
+2. Confirm `checksums.txt` matches uploaded assets.
+3. Confirm Authenticode signature verification passes for installer and app binary.
+4. Link incident summary in release checklist evidence for auditability.


### PR DESCRIPTION
## Summary
- add `docs/release-rollback-runbook.md` with release unpublish, tag handling, replacement strategy, and incident flow
- include checksum/signature invalidation communication template
- add signing key rotation + secret revocation guidance and link from runbook
- add runbook references into `docs/release-checklist.md`

## Validation
- `python -m unittest discover -s tests -p test_*.py -v`

Closes #78