### PR TITLE
build(release): harden publish preflight and checksum gates

### DIFF
--- a/scripts/publish_release.ps1
+++ b/scripts/publish_release.ps1
@@ -1,29 +1,170 @@
 param(
   [Parameter(Mandatory=$true)][string]$Version,
-  [Parameter(Mandatory=$true)][string]$ArtifactDir
+  [Parameter(Mandatory=$true)][string]$ArtifactDir,
+  [switch]$DryRun
 )
 
 $ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Assert-CommandAvailable {
+  param([Parameter(Mandatory=$true)][string]$Name)
+  if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+    throw "Required command '$Name' was not found in PATH."
+  }
+}
+
+function Invoke-CheckedCommand {
+  param(
+    [Parameter(Mandatory=$true)][string]$Description,
+    [Parameter(Mandatory=$true)][scriptblock]$Command
+  )
+
+  & $Command
+  if ($LASTEXITCODE -ne 0) {
+    throw "$Description failed with exit code $LASTEXITCODE."
+  }
+}
+
+function Resolve-ArtifactPath {
+  param([Parameter(Mandatory=$true)][string]$PathValue)
+  try {
+    $resolved = Resolve-Path -LiteralPath $PathValue -ErrorAction Stop
+  } catch {
+    throw "Artifact directory '$PathValue' does not exist."
+  }
+
+  if (-not (Test-Path -LiteralPath $resolved.Path -PathType Container)) {
+    throw "Artifact path '$($resolved.Path)' is not a directory."
+  }
+
+  return $resolved.Path
+}
+
+function Assert-RequiredArtifacts {
+  param(
+    [Parameter(Mandatory=$true)][string]$ArtifactPath,
+    [Parameter(Mandatory=$true)][string[]]$RequiredFileNames
+  )
+
+  foreach ($name in $RequiredFileNames) {
+    $path = Join-Path $ArtifactPath $name
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+      throw "Missing required artifact '$name' in '$ArtifactPath'."
+    }
+    if ((Get-Item -LiteralPath $path).Length -le 0) {
+      throw "Required artifact '$name' is empty."
+    }
+  }
+}
+
+function Write-Checksums {
+  param(
+    [Parameter(Mandatory=$true)][string]$ArtifactPath,
+    [Parameter(Mandatory=$true)][System.IO.FileInfo[]]$ArtifactFiles
+  )
+
+  if ($ArtifactFiles.Count -eq 0) {
+    throw "No artifact files available for checksum generation in '$ArtifactPath'."
+  }
+
+  $checksumsPath = Join-Path $ArtifactPath "checksums.txt"
+  $lines = foreach ($file in $ArtifactFiles) {
+    $hash = Get-FileHash -Algorithm SHA256 -Path $file.FullName
+    "{0}  {1}" -f $hash.Hash.ToLowerInvariant(), $file.Name
+  }
+
+  Set-Content -LiteralPath $checksumsPath -Value $lines -Encoding utf8
+  return $checksumsPath
+}
+
+function Verify-Checksums {
+  param(
+    [Parameter(Mandatory=$true)][string]$ArtifactPath,
+    [Parameter(Mandatory=$true)][string]$ChecksumsPath
+  )
+
+  if (-not (Test-Path -LiteralPath $ChecksumsPath -PathType Leaf)) {
+    throw "Checksum file '$ChecksumsPath' was not generated."
+  }
+
+  foreach ($line in Get-Content -LiteralPath $ChecksumsPath) {
+    if (-not $line.Trim()) {
+      continue
+    }
+    if ($line -notmatch '^(?<hash>[A-Fa-f0-9]{64})\s{2}(?<name>.+)$') {
+      throw "Invalid checksum line format: '$line'."
+    }
+
+    $expected = $Matches.hash.ToLowerInvariant()
+    $name = $Matches.name.Trim()
+    $filePath = Join-Path $ArtifactPath $name
+
+    if (-not (Test-Path -LiteralPath $filePath -PathType Leaf)) {
+      throw "Missing artifact referenced by checksums.txt: '$name'."
+    }
+
+    $actual = (Get-FileHash -Algorithm SHA256 -Path $filePath).Hash.ToLowerInvariant()
+    if ($expected -ne $actual) {
+      throw "Checksum mismatch for '$name'. Expected '$expected', got '$actual'."
+    }
+  }
+}
 
 if ($Version -notmatch '^\d+\.\d+\.\d+$') {
-  throw "Version must be semantic format like 1.0.0"
+  throw "Version must be semantic format like 1.0.0."
 }
+
+Assert-CommandAvailable -Name "git"
+Assert-CommandAvailable -Name "gh"
+
+$artifactPath = Resolve-ArtifactPath -PathValue $ArtifactDir
+$requiredArtifacts = @(
+  "ArenaCompanionSetup.exe",
+  "ArenaCompanion-onefolder.zip"
+)
+Assert-RequiredArtifacts -ArtifactPath $artifactPath -RequiredFileNames $requiredArtifacts
+
+$releaseNotesPath = (Resolve-Path -LiteralPath "docs/release-notes.md" -ErrorAction Stop).Path
+
+$artifactFilesForChecksums = Get-ChildItem -LiteralPath $artifactPath -File |
+  Where-Object { $_.Name -ne "checksums.txt" } |
+  Sort-Object Name
+
+if ($artifactFilesForChecksums.Count -eq 0) {
+  throw "Artifact directory '$artifactPath' does not contain release files."
+}
+
+$checksumsPath = Write-Checksums -ArtifactPath $artifactPath -ArtifactFiles $artifactFilesForChecksums
+Verify-Checksums -ArtifactPath $artifactPath -ChecksumsPath $checksumsPath
 
 $tag = "v$Version"
 
-if (git rev-parse --verify --quiet $tag) {
-  throw "Tag '$tag' already exists."
+if ($DryRun) {
+  Write-Host "Preflight passed for '$tag'. Dry run enabled; skipping tag creation and GitHub release publish."
+  exit 0
 }
 
-git tag -a $tag -m "Release $tag"
-git push origin $tag
+$null = git rev-parse --verify --quiet $tag 2>$null
+if ($LASTEXITCODE -eq 0) {
+  throw "Tag '$tag' already exists."
+}
+if ($LASTEXITCODE -gt 1) {
+  throw "Unable to verify whether tag '$tag' exists (exit code $LASTEXITCODE)."
+}
 
-$artifactPath = Resolve-Path $ArtifactDir
-$checksumsPath = Join-Path $artifactPath "checksums.txt"
-Get-ChildItem -Path $artifactPath -File | ForEach-Object {
-  $hash = Get-FileHash -Algorithm SHA256 -Path $_.FullName
-  "{0}  {1}" -f $hash.Hash.ToLower(), $_.Name
-} | Set-Content -LiteralPath $checksumsPath
+Invoke-CheckedCommand -Description "Create git tag '$tag'" -Command {
+  git tag -a $tag -m "Release $tag"
+}
 
-$artifactFiles = Get-ChildItem -Path $artifactPath -File | ForEach-Object { $_.FullName }
-gh release create $tag --title "Arena Companion $tag" --notes-file docs/release-notes.md @artifactFiles
+Invoke-CheckedCommand -Description "Push git tag '$tag' to origin" -Command {
+  git push origin $tag
+}
+
+$artifactFiles = Get-ChildItem -LiteralPath $artifactPath -File |
+  Sort-Object Name |
+  ForEach-Object { $_.FullName }
+
+Invoke-CheckedCommand -Description "Create GitHub release '$tag'" -Command {
+  gh release create $tag --title "Arena Companion $tag" --notes-file $releaseNotesPath @artifactFiles
+}


### PR DESCRIPTION
## Summary
- add strict preflight checks for artifact directory and required release files before any tag operations
- generate and verify `checksums.txt` before publish, with deterministic error messages
- add `-DryRun` mode for safe preflight validation without creating tags/releases
- add checked command execution wrappers for git/gh exit-code enforcement

## Testing
- `powershell -ExecutionPolicy Bypass -File scripts/publish_release.ps1 -Version 1.2.0 -ArtifactDir artifacts/release/1.2.0 -DryRun`
- Missing artifact failure proof:
  - run against temp artifact dir containing only `ArenaCompanion-onefolder.zip`
  - expected failure: `Missing required artifact 'ArenaCompanionSetup.exe' ...`
- `python -m unittest discover -s tests -p test_*.py -v`

Closes #89