### PR TITLE
ci(qa): remove ineffective pip cache from matrix tests

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -23,11 +23,6 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
-          cache-dependency-path: |
-            pyproject.toml
-            requirements.txt
-            requirements-ci.txt
 
       - name: Validate Release Version Sync
         run: |


### PR DESCRIPTION
## Summary
- remove pip cache settings from `tests_matrix` setup step in `Quality Gates`
- keeps matrix behavior the same while eliminating cache-path warning noise

## Testing
- `python -m unittest discover -s tests -p test_*.py -v`

Closes #103